### PR TITLE
ci: remove dev container forwarPorts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,6 @@
 		"dockerfile": "../local.Dockerfile"
 	},
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-	"forwardPorts": [
-		22222
-	],
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {
 			"version": "latest",


### PR DESCRIPTION
Multiple instance of container could be run at the same time result in port conflict.

Let VS code auto forward port